### PR TITLE
Set a correct ANDROID_ROOT when ANDROID_BUILD_TOP is provided

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -18,7 +18,7 @@ if [ -z "$ANDROID_BUILD_TOP" ]; then
     ANDROID_ROOT=$(realpath "$_self_dir/../")
     echo "WARNING: ANDROID_BUILD_TOP not set, guessing root at $ANDROID_ROOT"
 else
-    ANDROID_ROOT="$ANDROID_BUILD_TOP"
+    ANDROID_ROOT=$(realpath "$ANDROID_BUILD_TOP")
 fi
 
 _out=$ANDROID_ROOT/out/kernel-$_kernel_major$_kernel_minor/$_compiler/$_device


### PR DESCRIPTION
This way we can call place oot not just over ANDROID_ROOT
setting ANDROID_BUILD_TOP. In my case:

/repos/PE/10$ ANDROID_BUILD_TOP=. /repos/oot/oot.sh pdx201
==> Using clang /repos/PE/10/prebuilts/clang/host/linux-x86/clang-r353983d/bin
==> Entering /repos/PE/10/kernel/sony/msm-4.14/kernel
/repos/PE/10/kernel/sony/msm-4.14/kernel /repos/PE/10
==> Building aosp_seine_pdx201_defconfig
. . .