### PR TITLE
 compile_*: Drop broken realpath calls in compiler path setup

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -16,7 +16,7 @@ fi
 _out=$ANDROID_ROOT/out/kernel-$_kernel_major$_kernel_minor/$_compiler/$_device
 _kernel=$_out/arch/arm64/boot/Image.gz-dtb
 _make_vars="O=$_out ARCH=arm64 -j$(nproc)"
-_kernel_path=$(realpath $ANDROID_ROOT/kernel/sony/msm-$_kernel_major.$_kernel_minor/kernel)
+_kernel_path="$ANDROID_ROOT/kernel/sony/msm-$_kernel_major.$_kernel_minor/kernel"
 # True by default:
 if [ "$_recovery_ramdisk" = "false" ]; then
     _ramdisk=$ANDROID_ROOT/out/target/product/$_device/ramdisk.img

--- a/compile_clang.sh
+++ b/compile_clang.sh
@@ -1,10 +1,10 @@
 #! /usr/bin/bash
 
-_cross_compile=$(realpath "$ANDROID_ROOT/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/bin/aarch64-linux-android-")
-_cross_compile_32=$(realpath "$ANDROID_ROOT/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/bin/arm-linux-androideabi-")
+_cross_compile="$ANDROID_ROOT/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/bin/aarch64-linux-android-"
+_cross_compile_32="$ANDROID_ROOT/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/bin/arm-linux-androideabi-"
 # Get the clang version from current AOSP documentation
 _clang_version=$(awk '/^\* \[\*\*Android Linux Kernel/{f=NR} /^  \* Currently clang-/ && f==NR-1 {print $NF; exit}' $ANDROID_ROOT/prebuilts/clang/host/linux-x86/README.md)
-_clang_path=$(realpath "$ANDROID_ROOT/prebuilts/clang/host/linux-x86/$_clang_version/bin")
+_clang_path="$ANDROID_ROOT/prebuilts/clang/host/linux-x86/$_clang_version/bin"
 echo "==> Using clang $_clang_path"
 
 _defconfig=aosp_${_platform}_${_device}_defconfig

--- a/compile_gcc.sh
+++ b/compile_gcc.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/bash
 
-_cross_compile=$(realpath "$ANDROID_ROOT/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/bin/aarch64-linux-android-")
+_cross_compile="$ANDROID_ROOT/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/bin/aarch64-linux-android-"
 
 _defconfig=aosp_${_platform}_${_device}_defconfig
 

--- a/compile_linaro_gcc.sh
+++ b/compile_linaro_gcc.sh
@@ -2,7 +2,7 @@
 
 _cross_compile="/data/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-"
 _cross_compile="/data/gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-"
-_cross_compile_32=$(realpath "$ANDROID_ROOT/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/bin/arm-linux-androideabi-")
+_cross_compile_32="$ANDROID_ROOT/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/bin/arm-linux-androideabi-"
 
 _defconfig=aosp_${_platform}_${_device}_defconfig
 

--- a/create_images.sh
+++ b/create_images.sh
@@ -16,7 +16,7 @@ echo "==> Generating images for patch level $_os_patch_level"
 # mkdir -p $(dirname $_boot_out)
 
 if [[ "$_has_dtbo" == "true" ]]; then
-    _dts_folder=$(realpath "$_out/arch/arm64/boot/dts/qcom")
+    _dts_folder="$_out/arch/arm64/boot/dts/qcom"
     _files=$(find "$_dts_folder" -iname "*.dtbo")
     echo "==> Creating dtboimg from $_files"
     "$_kernel_path/scripts/mkdtboimg.py" create "$_device-dtbo.img" --page_size="$BOARD_KERNEL_PAGESIZE" "$_files"


### PR DESCRIPTION
These paths are compiler triple prefixes for binaries (compiler itself and other build tools) that do not point to a valid file or directory. `realpath` needs a valid file or directory in order to provide its actual location even if we are only interested in absolute paths.

As it turns out all these paths use `$ANDROID_ROOT` which is already made absolute, leaving little reason to keep the `realpath` invocations at all. They have hence been removed (instead of patched up like `"$(realpath "$ANDROID_ROOT/../")/aarch64-linux-android-"`).

(These paths have to be absolute to be reachable when entering the kernel source directory through `pushd`).

----

~@pablomh What do you think of this approach? `ANDROID_ROOT` is already absolute so `realpath` might as well disappear from these (and other paths) altogether, they were only to make sure the kernel build (which happens in a different directory) can still find the paths, but that's already taken care of.~ Removed all `realpath` calls`.