### PR TITLE
setup: Use gcc from PATH, move AOSP gcc to different file

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -42,9 +42,6 @@ _make_args="O=$_out ARCH=arm64 -j$(nproc)"
 _self_dir=$(realpath $(dirname "$0"))
 . $_self_dir/setup_$_compiler.sh
 
-_cross_compile_32="$ANDROID_ROOT/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/bin/arm-linux-androideabi-"
-_make_args+=" CROSS_COMPILE_ARM32=$_cross_compile_32"
-
 _build_cmd="make $_make_args"
 
 _defconfig=aosp_${_platform}_${_device}_defconfig

--- a/setup_aosp_gcc.sh
+++ b/setup_aosp_gcc.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/bash
+
+_cross_compile="$ANDROID_ROOT/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/bin/aarch64-linux-android-"
+# TODO: Cannot use gcc 4.9 since 4.14.218: https://github.com/sonyxperiadev/kernel/blame/409132320fe5e08d558e979ce92f39208e885010/include/linux/compiler-gcc.h#L155-L160
+_cross_compile_32="$ANDROID_ROOT/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/bin/arm-linux-androideabi-"
+
+_make_args+=" CROSS_COMPILE=$_cross_compile CROSS_COMPILE_ARM32=$_cross_compile_32"

--- a/setup_clang.sh
+++ b/setup_clang.sh
@@ -5,4 +5,7 @@ _cross_compile="$ANDROID_ROOT/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-andr
 _clang_version=$(awk '/^\* \[\*\*Android Linux Kernel/{f=NR} /^  \* Currently clang-/ && f==NR-1 {print $NF; exit}' "$ANDROID_ROOT/prebuilts/clang/host/linux-x86/README.md")
 _clang_path="$ANDROID_ROOT/prebuilts/clang/host/linux-x86/$_clang_version/bin"
 
-_make_args+=" CROSS_COMPILE=$_cross_compile CC=${_clang_path}/clang CLANG_TRIPLE=aarch64-linux-gnu"
+# TODO: Cannot use gcc 4.9 since 4.14.218: https://github.com/sonyxperiadev/kernel/blame/409132320fe5e08d558e979ce92f39208e885010/include/linux/compiler-gcc.h#L155-L160
+_cross_compile_32="$ANDROID_ROOT/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/bin/arm-linux-androideabi-"
+
+_make_args+=" CROSS_COMPILE=$_cross_compile CC=${_clang_path}/clang CLANG_TRIPLE=aarch64-linux-gnu CROSS_COMPILE_ARM32=$_cross_compile_32"

--- a/setup_gcc.sh
+++ b/setup_gcc.sh
@@ -1,5 +1,7 @@
 #! /usr/bin/bash
 
 _cross_compile="$ANDROID_ROOT/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/bin/aarch64-linux-android-"
+# TODO: Cannot use gcc 4.9 since 4.14.218: https://github.com/sonyxperiadev/kernel/blame/409132320fe5e08d558e979ce92f39208e885010/include/linux/compiler-gcc.h#L155-L160
+_cross_compile_32="$ANDROID_ROOT/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/bin/arm-linux-androideabi-"
 
-_make_args+=" CROSS_COMPILE=$_cross_compile"
+_make_args+=" CROSS_COMPILE=$_cross_compile CROSS_COMPILE_ARM32=$_cross_compile_32"

--- a/setup_gcc.sh
+++ b/setup_gcc.sh
@@ -1,7 +1,5 @@
 #! /usr/bin/bash
 
-_cross_compile="$ANDROID_ROOT/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/bin/aarch64-linux-android-"
-# TODO: Cannot use gcc 4.9 since 4.14.218: https://github.com/sonyxperiadev/kernel/blame/409132320fe5e08d558e979ce92f39208e885010/include/linux/compiler-gcc.h#L155-L160
-_cross_compile_32="$ANDROID_ROOT/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/bin/arm-linux-androideabi-"
+# Use gcc available on path. On archlinux, `pacman -S aarch64-linux-gnu-gcc arm-none-eabi-gcc`
 
-_make_args+=" CROSS_COMPILE=$_cross_compile CROSS_COMPILE_ARM32=$_cross_compile_32"
+_make_args+=" CROSS_COMPILE=aarch64-linux-gnu- CROSS_COMPILE_ARM32=arm-none-eabi-"

--- a/setup_linaro_gcc.sh
+++ b/setup_linaro_gcc.sh
@@ -1,6 +1,7 @@
 #! /usr/bin/bash
 
-_cross_compile="/data/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-"
 _cross_compile="/data/gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-"
+# TODO: Cannot use gcc 4.9 since 4.14.218: https://github.com/sonyxperiadev/kernel/blame/409132320fe5e08d558e979ce92f39208e885010/include/linux/compiler-gcc.h#L155-L160
+_cross_compile_32="$ANDROID_ROOT/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/bin/arm-linux-androideabi-"
 
-_make_args+=" CROSS_COMPILE=$_cross_compile"
+_make_args+=" CROSS_COMPILE=$_cross_compile CROSS_COMPILE_ARM32=$_cross_compile_32"


### PR DESCRIPTION
Migrate deprecated AOSP gcc to a separate compiler target, `aosp_gcc`, while using the `gcc` target for a more recent and more relevant compiler that might be installed on ones system. The script can easily be called with `PATH=/path/to/your/arm/gcc:/and/aarch64 ./oot.sh` as well.

---

@pablomh would you mind reviewing this?
