### PR TITLE
ci: Lint included source files through `shellcheck -a`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,4 +15,4 @@ jobs:
       - name: Shellcheck version
         run: shellcheck -V
       - name: Run shellcheck
-        run: shellcheck -x oot.sh
+        run: shellcheck -ax oot.sh

--- a/compile.sh
+++ b/compile.sh
@@ -19,8 +19,10 @@ fi
 
 _make_args="O=$_out ARCH=arm64 -j$(nproc)"
 
-_self_dir=$(realpath $(dirname "$0"))
-. $_self_dir/setup_$_compiler.sh
+_self_dir=$(realpath "$(dirname "$0")")
+# Assume gcc for shellcheck, not too relevant
+# shellcheck source=setup_gcc.sh
+. "$_self_dir/setup_${_compiler}.sh"
 
 _build_cmd="make $_make_args"
 
@@ -30,9 +32,11 @@ echo "==> Entering $_kernel_path"
 pushd "$_kernel_path" || (echo "ERROR: Failed to cd into kernel source!"; exit 1)
 
     echo "==> Building $_defconfig"
-    $_build_cmd $_defconfig
+    $_build_cmd "$_defconfig"
 
     echo "==> Building $_targets with $_compiler"
+    # _targets requires word splitting
+    # shellcheck disable=SC2086
     time $_build_cmd $_targets
 
     echo "==> $_targets compiled successfully"

--- a/create_images.sh
+++ b/create_images.sh
@@ -13,6 +13,12 @@ _os_version=10
 
 echo "==> Generating images for patch level $_os_patch_level"
 
+# True by default, analogous to BOARD_USES_RECOVERY_AS_BOOT:
+[ "$_recovery_ramdisk" = "false" ] && _ramdisk=ramdisk.img || _ramdisk=ramdisk-recovery.img
+_ramdisk=$ANDROID_ROOT/out/target/product/$_device/$_ramdisk
+
+[ ! -f "$_ramdisk" ] && echo "WARNING: $_ramdisk does not exist!"
+
 # mkdir -p $(dirname $_boot_out)
 
 if [[ "$_has_dtbo" == "true" ]]; then
@@ -20,12 +26,9 @@ if [[ "$_has_dtbo" == "true" ]]; then
     _files=$(find "$_dts_folder" -iname "*.dtbo")
     echo "==> Creating dtboimg from $_files"
     _mkdtboimg="$_kernel_path/scripts/mkdtboimg.py"
-    if [[ ! -f "$_mkdtboimg" ]]; then
-        _mkdtboimg="$ANDROID_ROOT/prebuilts/misc/linux-x86/libufdt/mkdtimg"
-    fi
-    if [[ ! -f "$_mkdtboimg" ]]; then
-        _mkdtboimg="$ANDROID_ROOT/system/libufdt/utils/src/mkdtboimg.py"
-    fi
+    [[ ! -f "$_mkdtboimg" ]] && _mkdtboimg="$ANDROID_ROOT/prebuilts/misc/linux-x86/libufdt/mkdtimg"
+    [[ ! -f "$_mkdtboimg" ]] && _mkdtboimg="$ANDROID_ROOT/system/libufdt/utils/src/mkdtboimg.py"
+    [[ ! -f "$_mkdtboimg" ]] && (echo "No mkdtbo script/executable found"; exit 1)
     echo "==> Using mkdtbo at $_mkdtboimg"
     # --page_size="$BOARD_KERNEL_PAGESIZE"
     "$_mkdtboimg" create "$_device-dtbo.img" $_files

--- a/create_images.sh
+++ b/create_images.sh
@@ -31,10 +31,12 @@ if [[ "$_has_dtbo" == "true" ]]; then
     [[ ! -f "$_mkdtboimg" ]] && (echo "No mkdtbo script/executable found"; exit 1)
     echo "==> Using mkdtbo at $_mkdtboimg"
     # --page_size="$BOARD_KERNEL_PAGESIZE"
+    # _files requires word splitting (Tama has multiple dtbo files)
+    # shellcheck disable=SC2086
     "$_mkdtboimg" create "$_device-dtbo.img" $_files
 fi
 
-if [[ "$_permissive" == "true" ]]; then
+if [[ "${_permissive:-false}" == "true" ]]; then
     echo "==> Adding permissive to cmdline"
     BOARD_KERNEL_CMDLINE+=" androidboot.selinux=permissive"
     #  enforcing=0 selinux=0
@@ -55,6 +57,6 @@ echo "$BOARD_KERNEL_CMDLINE"
 
 echo "==> Creating $_boot_out..."
 
-$ANDROID_ROOT/out/host/linux-x86/bin/mkbootimg --kernel "$_kernel" --ramdisk "$_ramdisk" --cmdline "$BOARD_KERNEL_CMDLINE" --base "$BOARD_KERNEL_BASE" --pagesize "$BOARD_KERNEL_PAGESIZE" --os_version "$_os_version" --os_patch_level "$_os_patch_level" --ramdisk_offset "$BOARD_RAMDISK_OFFSET" --tags_offset "$BOARD_KERNEL_TAGS_OFFSET" --output "$_boot_out" --id
+"$ANDROID_ROOT/out/host/linux-x86/bin/mkbootimg" --kernel "$_kernel" --ramdisk "$_ramdisk" --cmdline "$BOARD_KERNEL_CMDLINE" --base "$BOARD_KERNEL_BASE" --pagesize "$BOARD_KERNEL_PAGESIZE" --os_version "$_os_version" --os_patch_level "$_os_patch_level" --ramdisk_offset "$BOARD_RAMDISK_OFFSET" --tags_offset "$BOARD_KERNEL_TAGS_OFFSET" --output "$_boot_out" --id
 
 echo "==> mkbootimg successful, created $_boot_out"

--- a/setup_gcc.sh
+++ b/setup_gcc.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/bash
 
-# Use gcc available on path. On archlinux, `pacman -S aarch64-linux-gnu-gcc arm-none-eabi-gcc`
+# Use gcc available on PATH. On archlinux, `pacman -S aarch64-linux-gnu-gcc arm-none-eabi-gcc`
 
 _make_args+=" CROSS_COMPILE=aarch64-linux-gnu- CROSS_COMPILE_ARM32=arm-none-eabi-"


### PR DESCRIPTION
Depends on #14 

`shellcheck -x` only reads external sources to discover unused variables in the top-level file, and needs the `-a` flag to also apply linting to imported/included shell files.